### PR TITLE
Make paths to pid and log configurable

### DIFF
--- a/lib/rsense/client/runner.rb
+++ b/lib/rsense/client/runner.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 require 'rubygems'
 require 'spoon'
 
@@ -8,11 +9,13 @@ module Rsense
 
       APPNAME = 'rsense'
       WORK_PATH = Dir.pwd
-      PID_PATH  = '/tmp/rsense.pid'
-      OUT_PATH = '/tmp/rsense.log'
+      # TODO: Make this configurable w/out ENV variables
+      PID_PATH  = ENV['RSENSE_PID'] || '/tmp'
+      OUT_PATH = ENV['RSENSE_LOG'] || '/tmp'
       EXEC = "/usr/bin/env"
 
       def initialize(args={})
+        ensure_paths_exist(PID_PATH, OUT_PATH)
         @args = args
       end
 
@@ -22,11 +25,11 @@ module Rsense
 
       def create_pid(pid)
         begin
-          open(PID_PATH, 'w') do |f|
+          open(pid_path, 'w') do |f|
             f.puts pid
           end
         rescue => e
-          STDERR.puts "Error: Unable to open #{PID_PATH} for writing:\n\t" +
+          STDERR.puts "Error: Unable to open #{pid_path} for writing:\n\t" +
               "(#{e.class}) #{e.message}"
           exit!
         end
@@ -35,12 +38,12 @@ module Rsense
       def get_pid
         pid = false
         begin
-          open(PID_PATH, 'r') do |f|
+          open(pid_path, 'r') do |f|
             pid = f.readline
             pid = pid.to_s.gsub(/[^0-9]/,'')
           end
         rescue => e
-          STDERR.puts "Error: Unable to open #{PID_PATH} for reading:\n\t" +
+          STDERR.puts "Error: Unable to open #{pid_path} for reading:\n\t" +
               "(#{e.class}) #{e.message}"
           exit
         end
@@ -50,7 +53,7 @@ module Rsense
 
       def remove_pidfile
         begin
-          File.unlink(PID_PATH)
+          File.unlink(pid_path)
         rescue => e
           STDERR.puts "ERROR: Unable to unlink #{path}:\n\t" +
             "(#{e.class}) #{e.message}"
@@ -108,12 +111,26 @@ module Rsense
         Dir::chdir(WORK_PATH)
         file_actions = Spoon::FileActions.new
         file_actions.close(1)
-        file_actions.open(1, OUT_PATH, File::WRONLY | File::TRUNC | File::CREAT, 0600)
+        file_actions.open(1, out_path, File::WRONLY | File::TRUNC | File::CREAT, 0600)
         file_actions.close(2)
-        file_actions.open(2, OUT_PATH, File::WRONLY | File::TRUNC | File::CREAT, 0600)
+        file_actions.open(2, out_path, File::WRONLY | File::TRUNC | File::CREAT, 0600)
         spawn_attr =  Spoon::SpawnAttributes.new
         pid = Spoon.posix_spawn EXEC, file_actions, spawn_attr, @args
         create_pid(pid)
+      end
+
+      def pid_path
+        File.join(PID_PATH, "rsense.pid")
+      end
+
+      def out_path
+        File.join(OUT_PATH, "rsense.log")
+      end
+
+      def ensure_paths_exist(*paths)
+        paths.each do |path|
+          FileUtils.mkdir_p(path) unless File.directory?(path)
+        end
       end
     end
   end

--- a/lib/rsense/client/runner.rb
+++ b/lib/rsense/client/runner.rb
@@ -49,8 +49,8 @@ module Rsense
       end
 
       def remove_pidfile
-       begin
-         File.unlink(PID_PATH)
+        begin
+          File.unlink(PID_PATH)
         rescue => e
           STDERR.puts "ERROR: Unable to unlink #{path}:\n\t" +
             "(#{e.class}) #{e.message}"

--- a/spec/rsense/client/daemon_spec.rb
+++ b/spec/rsense/client/daemon_spec.rb
@@ -74,7 +74,7 @@ describe Rsense::Client::Daemon do
 
     it "should initialize a runner" do
       daemon = Rsense::Client::Daemon.new(["foo", "bar"])
-      daemon.runner.class::PID_PATH.must_match(/tmp\/rsense\.pid/)
+      daemon.runner.class::PID_PATH.must_match(Rsense::Client::Runner::PID_PATH)
     end
 
     it "should delegate start method to runner" do

--- a/spec/rsense/client/runner_spec.rb
+++ b/spec/rsense/client/runner_spec.rb
@@ -1,0 +1,33 @@
+require_relative "../../spec_helper"
+require 'fileutils'
+
+describe Rsense::Client::Runner do
+  before do
+    @runner = Rsense::Client::Runner.new
+  end
+
+  describe "#ensure_paths_exists" do
+    let(:filepath) { "/tmp/rsense-test" }
+
+    before(:each) do
+      FileUtils.rm_r(filepath) if File.directory?(filepath)
+    end
+
+    after(:each) do
+      FileUtils.rm_r(filepath) if File.directory?(filepath)
+    end
+
+    it "creates directories when they don't exists" do
+      File.directory?(filepath).must_equal(false)
+      @runner.ensure_paths_exist(filepath)
+      File.directory?(filepath).must_equal(true)
+    end
+
+    it "doesn't do anything when directories exists" do
+      FileUtils.mkdir_p(filepath)
+      File.directory?(filepath).must_equal(true)
+      @runner.ensure_paths_exist(filepath)
+      File.directory?(filepath).must_equal(true)
+    end
+  end
+end


### PR DESCRIPTION
I started to make the default paths `/var/run` and `/var/log` to follow unix conventions... but then I realized that would require the user to have permissions to `/var` or run rsense with sudo... Since that sounded like a bad default I opted for making the paths configurable. At some point I'll contribute to the wiki on how to configure rsense differently. Ultimately it make make sense to actually allow for a config file, but for the moment I just went with ENV variables.
